### PR TITLE
Parse date to tz instead of converting

### DIFF
--- a/app/scripts/mbdatepicker.coffee
+++ b/app/scripts/mbdatepicker.coffee
@@ -229,7 +229,7 @@ app.directive('mbDatepicker', ['$filter', ($filter)->
       scope.$watch (() -> return scope.tz), (() -> ngModel[0].$render())
       # our model changed
       ngModel[0].$render = () ->
-        dateChanged(moment(ngModel[0].$viewValue).tz(getTimezone()), true)
+        dateChanged(moment.tz(ngModel[0].$viewValue, scope.dateFormat || 'YYYY-MM-DD', getTimezone()), true)
     init()
 
 

--- a/build/mbdatepicker.js
+++ b/build/mbdatepicker.js
@@ -224,7 +224,7 @@
               return ngModel[0].$render();
             }));
             return ngModel[0].$render = function() {
-              return dateChanged(moment(ngModel[0].$viewValue).tz(getTimezone()), true);
+              return dateChanged(moment.tz(ngModel[0].$viewValue, scope.dateFormat || 'YYYY-MM-DD', getTimezone()), true);
             };
           };
           return init();


### PR DESCRIPTION
Instead of converting the date to the set timezone, parse the date into a moment object of the timezone. Fixes a bug where date is not displayed correctly when local timezone is different from set timezone